### PR TITLE
Refactor Telegram bot conversation flow

### DIFF
--- a/suskia.py
+++ b/suskia.py
@@ -1,219 +1,421 @@
+"""Telegram bot implementation for running an Undercover style party game.
+
+The original project already contained most of the game rules, but the control
+flow mixed Telegram specific logic with game state in a way that made the bot
+hard to use.  This module restructures the code around the
+``python-telegram-bot`` conversation API so every action (player count, role
+distribution, card selection and elimination) is driven by a dedicated handler
+with clear transitions between the conversation states.
+"""
+
+from __future__ import annotations
+
 import logging
 import random
-from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update, ParseMode
-from telegram.ext import Updater, CommandHandler, CallbackContext, CallbackQueryHandler, ConversationHandler
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
 
-# Enable logging
-logging.basicConfig(format='%(asctime)s - %(name)s - %(levelname)s - %(message)s', level=logging.INFO)
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
+from telegram.ext import (
+    ApplicationBuilder,
+    CallbackQueryHandler,
+    CommandHandler,
+    ConversationHandler,
+    ContextTypes,
+)
+
+# Enable logging so it is easier to debug when the bot is running live.
+logging.basicConfig(
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    level=logging.INFO,
+)
 logger = logging.getLogger(__name__)
 
-# States for the conversation
-SELECTING_PLAYERS, ROLES_SELECTION, SELECTING_CARDS, ELIMINATING, GAME_OVER = range(5)
 
-# Global variables to store game data
-num_players = 0
-player_dict = {}
-player_order = []
-words_library = {
-    'C': ['DOG'],  # Add more civilian words as needed
-    'U': ['WOLF'],  # Add more undercover words as needed
+# Conversation states
+SELECTING_PLAYERS, ROLES_SELECTION, SELECTING_CARDS, ELIMINATING = range(4)
+
+
+# Default role distributions for the supported number of players.
+ROLE_PRESETS: Dict[int, List[tuple[int, int, int]]] = {
+    3: [(2, 1, 0), (2, 0, 1)],
+    4: [(3, 1, 0), (2, 1, 1)],
+    5: [(3, 2, 0), (3, 1, 1)],
+    6: [(4, 1, 1), (3, 2, 1)],
+    7: [(4, 2, 1), (5, 1, 1)],
+    8: [(5, 2, 1), (4, 3, 1)],
+    9: [(6, 2, 1), (5, 3, 1)],
+    10: [(6, 3, 1), (5, 3, 2)],
 }
 
 
-def start(update: Update, context: CallbackContext) -> int:
-    keyboard = [
-        [InlineKeyboardButton(str(i), callback_data=str(i)) for i in range(3, 11)]
-    ]
-    reply_markup = InlineKeyboardMarkup(keyboard)
-    update.message.reply_text("How many players? (3-10)", reply_markup=reply_markup)
+ROLE_NAMES = {
+    "C": "Civilian",
+    "U": "Undercover",
+    "W": "Mr. White",
+}
 
+ROLE_POINTS = {"C": 1, "U": 2, "W": 4}
+
+WORDS_LIBRARY = {
+    "C": ["APPLE", "MOUNTAIN", "SPACESHIP", "GUITAR"],
+    "U": ["ORANGE", "HILL", "ROCKET", "VIOLIN"],
+    "W": ["Invent your own word!"]
+}
+
+
+@dataclass
+class Player:
+    """Stores the state for a single player in the session."""
+
+    seat: int
+    role: str = ""
+    word: str = ""
+    eliminated: bool = False
+    card: Optional[int] = None
+    score: int = 0
+
+
+@dataclass
+class GameSession:
+    """In-memory representation of the current match for a chat."""
+
+    num_players: int
+    players: Dict[int, Player] = field(init=False)
+    pending_seats: List[int] = field(init=False)
+    available_cards: List[int] = field(init=False)
+    elimination_log: List[int] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        self.players = {seat: Player(seat=seat) for seat in range(1, self.num_players + 1)}
+        self.pending_seats = list(self.players.keys())
+        self.available_cards = list(self.players.keys())
+
+    # --- helpers for role assignment -------------------------------------------------
+    def assign_roles(self, civilians: int, undercovers: int, mr_white: int) -> None:
+        seats = list(self.players.keys())
+        random.shuffle(seats)
+
+        index = 0
+        for _ in range(civilians):
+            seat = seats[index]
+            index += 1
+            player = self.players[seat]
+            player.role = "C"
+            player.word = random.choice(WORDS_LIBRARY["C"])
+
+        for _ in range(undercovers):
+            seat = seats[index]
+            index += 1
+            player = self.players[seat]
+            player.role = "U"
+            player.word = random.choice(WORDS_LIBRARY["U"])
+
+        for _ in range(mr_white):
+            seat = seats[index]
+            index += 1
+            player = self.players[seat]
+            player.role = "W"
+            player.word = random.choice(WORDS_LIBRARY["W"])
+
+        # Reset the card selection order whenever roles are reassigned.
+        self.pending_seats = list(self.players.keys())
+        self.available_cards = list(self.players.keys())
+
+    # --- helpers for card selection --------------------------------------------------
+    def register_card_choice(self, card_value: int) -> Player:
+        seat = self.pending_seats.pop(0)
+        player = self.players[seat]
+        player.card = card_value
+        self.available_cards.remove(card_value)
+        return player
+
+    def elimination_queue(self) -> List[Player]:
+        return sorted(
+            self.players.values(),
+            key=lambda p: (p.card is None, p.card if p.card is not None else 0, p.seat),
+        )
+
+    # --- helpers for elimination -----------------------------------------------------
+    def active_players(self) -> List[Player]:
+        return [player for player in self.players.values() if not player.eliminated]
+
+    def civilians_remaining(self) -> int:
+        return sum(1 for player in self.active_players() if player.role == "C")
+
+    def infiltrators_remaining(self) -> int:
+        return sum(1 for player in self.active_players() if player.role in {"U", "W"})
+
+    def eliminate(self, seat: int) -> Player:
+        player = self.players[seat]
+        player.eliminated = True
+        self.elimination_log.append(seat)
+        return player
+
+    def outcome(self) -> Optional[str]:
+        infiltrators = self.infiltrators_remaining()
+        civilians = self.civilians_remaining()
+        if infiltrators == 0:
+            return "civilians"
+        if civilians <= infiltrators:
+            return "infiltrators"
+        return None
+
+
+def build_number_keyboard() -> InlineKeyboardMarkup:
+    buttons: List[List[InlineKeyboardButton]] = []
+    row: List[InlineKeyboardButton] = []
+    for number in range(3, 11):
+        row.append(InlineKeyboardButton(str(number), callback_data=f"players:{number}"))
+        if len(row) == 4:
+            buttons.append(row)
+            row = []
+    if row:
+        buttons.append(row)
+    return InlineKeyboardMarkup(buttons)
+
+
+def build_roles_keyboard(num_players: int) -> InlineKeyboardMarkup:
+    presets = ROLE_PRESETS.get(num_players, [])
+    buttons = []
+    for civilians, undercovers, mr_white in presets:
+        label = f"{civilians} Civ, {undercovers} U, {mr_white} W"
+        data = f"roles:{civilians}:{undercovers}:{mr_white}"
+        buttons.append([InlineKeyboardButton(label, callback_data=data)])
+    return InlineKeyboardMarkup(buttons)
+
+
+def build_card_keyboard(session: GameSession) -> InlineKeyboardMarkup:
+    buttons: List[List[InlineKeyboardButton]] = []
+    row: List[InlineKeyboardButton] = []
+    for card in session.available_cards:
+        row.append(InlineKeyboardButton(str(card), callback_data=f"card:{card}"))
+        if len(row) == 5:
+            buttons.append(row)
+            row = []
+    if row:
+        buttons.append(row)
+    return InlineKeyboardMarkup(buttons)
+
+
+def build_elimination_keyboard(session: GameSession) -> InlineKeyboardMarkup:
+    buttons = [
+        [InlineKeyboardButton(f"Player {seat}", callback_data=f"eliminate:{seat}")]
+        for seat in sorted(player.seat for player in session.active_players())
+    ]
+    return InlineKeyboardMarkup(buttons)
+
+
+async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    context.chat_data.pop("session", None)
+    logger.info("Starting new game in chat %s", update.effective_chat.id if update.effective_chat else "N/A")
+    if update.message:
+        await update.message.reply_text(
+            "How many players are taking part?",
+            reply_markup=build_number_keyboard(),
+        )
     return SELECTING_PLAYERS
 
 
-def select_players(update: Update, context: CallbackContext) -> int:
+async def select_players(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     query = update.callback_query
-    global num_players
-    num_players = int(query.data)
+    if not query:
+        return SELECTING_PLAYERS
+    await query.answer()
 
-    if num_players < 3 or num_players > 10:
-        query.message.reply_text("Invalid number of players.")
+    try:
+        num_players = int(query.data.split(":", 1)[1])
+    except (ValueError, IndexError):
+        await query.edit_message_text("Could not determine the number of players. Try again with /start.")
+        return ConversationHandler.END
+
+    if num_players not in ROLE_PRESETS:
+        await query.edit_message_text("Please choose a number between 3 and 10.")
         return SELECTING_PLAYERS
 
-    # Create entries for each player in the dictionary
-    for i in range(1, num_players + 1):
-        player_dict[i] = {'name': '', 'role': '', 'word': '', 'eliminated': False, 'score': 0}
+    session = GameSession(num_players)
+    context.chat_data["session"] = session
 
-    # Move to the roles selection state
-    query.message.reply_text("How do you want to distribute the roles?", reply_markup=get_roles_keyboard(num_players))
-
+    await query.edit_message_text(
+        f"Game setup for {num_players} players. Choose how to distribute the roles:",
+    )
+    await query.message.reply_text("Select one of the distributions below:", reply_markup=build_roles_keyboard(num_players))
     return ROLES_SELECTION
 
 
-def get_roles_keyboard(num_players):
-    if num_players == 3:
-        keyboard = [
-            [InlineKeyboardButton("2 C, 1 U, 0 W", callback_data="2C1U0W")],
-            [InlineKeyboardButton("2 C, 0 U, 1 W", callback_data="2C0U1W")],
-        ]
-    # Implement the rest of the role distributions here based on num_players
-    # ...
-
-    return InlineKeyboardMarkup(keyboard)
-
-
-def select_roles(update: Update, context: CallbackContext) -> int:
+async def select_roles(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     query = update.callback_query
-    roles = query.data
-    num_civilians = int(roles[0])
-    num_undercovers = int(roles[2])
-    num_mr_white = int(roles[4])
+    if not query:
+        return ROLES_SELECTION
+    await query.answer()
 
-    if num_civilians + num_undercovers + num_mr_white != num_players:
-        query.message.reply_text("Invalid role distribution.")
+    session: Optional[GameSession] = context.chat_data.get("session")
+    if not session:
+        await query.edit_message_text("Game session not found. Start a new game with /start.")
+        return ConversationHandler.END
+
+    try:
+        _, civilians, undercovers, mr_white = query.data.split(":")
+        civilians = int(civilians)
+        undercovers = int(undercovers)
+        mr_white = int(mr_white)
+    except (ValueError, IndexError):
+        await query.edit_message_text("Invalid role selection. Please pick a preset from the keyboard.")
         return ROLES_SELECTION
 
-    # Assign roles to players randomly
-    players = list(range(1, num_players + 1))
-    random.shuffle(players)
-    for i in range(num_civilians):
-        player_dict[players[i]]['role'] = 'C'
-    for i in range(num_civilians, num_civilians + num_undercovers):
-        player_dict[players[i]]['role'] = 'U'
-    for i in range(num_civilians + num_undercovers, num_civilians + num_undercovers + num_mr_white):
-        player_dict[players[i]]['role'] = 'W'
+    if civilians + undercovers + mr_white != session.num_players:
+        await query.edit_message_text("The distribution does not match the number of players.")
+        return ROLES_SELECTION
 
-    # Create player order for elimination
-    global player_order
-    player_order = players.copy()
-    player_order.remove(players[num_civilians + num_undercovers + num_mr_white - 1])
-    player_order.insert(1, players[num_civilians + num_undercovers + num_mr_white - 1])
+    session.assign_roles(civilians, undercovers, mr_white)
 
-    # Move to the selecting cards state
-    query.message.reply_text(f"Playing a game with {num_civilians} C, {num_undercovers} U, {num_mr_white} W")
-    context.user_data['current_player'] = 0
-    show_card_keyboard(update, context)
+    await query.edit_message_text(
+        f"Roles assigned! {civilians} Civilians, {undercovers} Undercover(s) and {mr_white} Mr. White.",
+    )
 
+    await query.message.reply_text(
+        f"Player {session.pending_seats[0]}, please choose a card to determine the turn order.",
+        reply_markup=build_card_keyboard(session),
+    )
     return SELECTING_CARDS
 
 
-def show_card_keyboard(update: Update, context: CallbackContext):
-    context.user_data['current_player'] += 1
-    current_player = context.user_data['current_player']
-
-    # Filter out already chosen cards from the keyboard
-    available_cards = list(range(1, num_players + 1))
-    for player in player_dict.values():
-        if player['role'] != '':  # Skip players who have already chosen a card
-            available_cards.remove(player['card'])
-
-    keyboard = [
-        [InlineKeyboardButton(str(card), callback_data=str(card)) for card in available_cards]
-    ]
-    reply_markup = InlineKeyboardMarkup(keyboard)
-    update.message.reply_text(f"Player {current_player}, choose your card:", reply_markup=reply_markup)
-
-
-def select_card(update: Update, context: CallbackContext) -> int:
+async def select_card(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     query = update.callback_query
-    card = int(query.data)
-    current_player = context.user_data['current_player']
+    if not query:
+        return SELECTING_CARDS
+    await query.answer()
 
-    # Store the selected card for the current player
-    player_dict[current_player]['card'] = card
+    session: Optional[GameSession] = context.chat_data.get("session")
+    if not session:
+        await query.edit_message_text("Game session not found. Start a new game with /start.")
+        return ConversationHandler.END
 
-    # Move to the next player or start elimination if all players have chosen a card
-    if len([player for player in player_dict.values() if player['card'] == 0]) == 0:
-        query.message.reply_text(f"The order of players for elimination: {', '.join([str(player_order[i]) for i in range(1, len(player_order))])}.")
-        eliminate_player(update, context)
-    else:
-        show_card_keyboard(update, context)
+    try:
+        card_value = int(query.data.split(":", 1)[1])
+    except (ValueError, IndexError):
+        await query.edit_message_text("That card could not be processed. Try again.")
         return SELECTING_CARDS
 
+    if card_value not in session.available_cards:
+        await query.answer("Card already taken. Pick another one.", show_alert=True)
+        return SELECTING_CARDS
 
-def eliminate_player(update: Update, context: CallbackContext):
-    # Show a keyboard with remaining active players to eliminate
-    remaining_players = [player for player in player_dict.values() if not player['eliminated']]
-    keyboard = [
-        [InlineKeyboardButton(f"Player {player['id']}", callback_data=str(player['id']))] for player in remaining_players
-    ]
-    reply_markup = InlineKeyboardMarkup(keyboard)
-    update.message.reply_text("Select a player to eliminate:", reply_markup=reply_markup)
+    player = session.register_card_choice(card_value)
+    await query.edit_message_text(f"Player {player.seat} chose card {card_value}.")
 
+    if session.pending_seats:
+        next_player = session.pending_seats[0]
+        await query.message.reply_text(
+            f"Player {next_player}, choose your card:",
+            reply_markup=build_card_keyboard(session),
+        )
+        return SELECTING_CARDS
+
+    order = session.elimination_queue()
+    order_text = ", ".join(
+        f"Player {p.seat} (card {p.card})" if p.card is not None else f"Player {p.seat}"
+        for p in order
+    )
+    await query.message.reply_text(f"Elimination order based on cards: {order_text}")
+    await query.message.reply_text(
+        "Select a player to eliminate:",
+        reply_markup=build_elimination_keyboard(session),
+    )
     return ELIMINATING
 
 
-def handle_elimination(update: Update, context: CallbackContext) -> int:
+async def handle_elimination(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
     query = update.callback_query
-    player_id = int(query.data)
+    if not query:
+        return ELIMINATING
+    await query.answer()
 
-    # Eliminate the selected player
-    player_dict[player_id]['eliminated'] = True
+    session: Optional[GameSession] = context.chat_data.get("session")
+    if not session:
+        await query.edit_message_text("Game session not found. Start a new game with /start.")
+        return ConversationHandler.END
 
-    # Check if all infiltrators (undercover or mr white) have been eliminated
-    infiltrators_remaining = len([player for player in player_dict.values() if
-                                  not player['eliminated'] and player['role'] in ('U', 'W')])
-    civilians_remaining = len([player for player in player_dict.values() if
-                               not player['eliminated'] and player['role'] == 'C'])
-    mr_white_remaining = len([player for player in player_dict.values() if
-                              not player['eliminated'] and player['role'] == 'W'])
+    try:
+        seat = int(query.data.split(":", 1)[1])
+    except (ValueError, IndexError):
+        await query.edit_message_text("Invalid selection. Try again.")
+        return ELIMINATING
 
-    if mr_white_remaining == 0:
-        # Mr. White is eliminated, civilians win
-        query.message.reply_text("Mr. White has been eliminated. Civilians win this round!")
-    elif infiltrators_remaining == 0:
-        # All infiltrators are eliminated, civilians win
-        query.message.reply_text("All infiltrators have been eliminated. Civilians win this round!")
+    player = session.players.get(seat)
+    if not player or player.eliminated:
+        await query.answer("That player is already out.", show_alert=True)
+        return ELIMINATING
+
+    session.eliminate(seat)
+    await query.edit_message_text(
+        f"Player {seat} has been eliminated and was {ROLE_NAMES.get(player.role, 'Unknown')}!"
+    )
+
+    outcome = session.outcome()
+    if outcome:
+        await announce_winner(query, session, outcome)
+        context.chat_data.pop("session", None)
+        return ConversationHandler.END
+
+    await query.message.reply_text(
+        "Select the next player to eliminate:",
+        reply_markup=build_elimination_keyboard(session),
+    )
+    return ELIMINATING
+
+
+async def announce_winner(query, session: GameSession, outcome: str) -> None:
+    message = query.message
+    if outcome == "civilians":
+        await message.reply_text("All infiltrators have been eliminated. Civilians win this round!")
     else:
-        # There are remaining infiltrators, continue the elimination
-        eliminate_player(update, context)
+        await message.reply_text("Infiltrators now outnumber civilians. Undercover team wins!")
 
-    return SELECTING_CARDS
+    scoreboard_lines = []
+    for seat in sorted(session.players):
+        player = session.players[seat]
+        player.score = ROLE_POINTS.get(player.role, 0)
+        scoreboard_lines.append(
+            f"Player {seat}: {ROLE_NAMES.get(player.role, 'Unknown')} - {player.score} point(s)."
+        )
 
-
-def end_game(update: Update, context: CallbackContext) -> int:
-    # Calculate and display the standings
-    standings = []
-    for player in player_dict.values():
-        if player['role'] == 'C':
-            player['score'] += 1
-        elif player['role'] == 'U':
-            player['score'] += 2
-        elif player['role'] == 'W':
-            player['score'] += 4
-        standings.append(f"Player {player['id']}: {player['score']} points")
-
-    query.message.reply_text("\n".join(standings))
-    query.message.reply_text("The game is over. Do you want to continue or end?")
-
-    return GAME_OVER
+    await message.reply_text("Final roles:\n" + "\n".join(scoreboard_lines))
+    await message.reply_text("Game over! Use /start to play again or /end to stop the bot.")
 
 
-def main():
-    # Set up the Telegram Bot token
+async def cancel_game(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    context.chat_data.pop("session", None)
+    if update.callback_query:
+        await update.callback_query.answer()
+        await update.callback_query.edit_message_text("Game cancelled.")
+    elif update.message:
+        await update.message.reply_text("Game cancelled.")
+    return ConversationHandler.END
+
+
+def main() -> None:
     bot_token = "YOUR_BOT_TOKEN"
 
-    updater = Updater(bot_token)
-    dp = updater.dispatcher
+    application = ApplicationBuilder().token(bot_token).build()
 
-    # Define conversation handler
     conv_handler = ConversationHandler(
-        entry_points=[CommandHandler('start', start)],
+        entry_points=[CommandHandler("start", start)],
         states={
-            SELECTING_PLAYERS: [CallbackQueryHandler(select_players)],
-            ROLES_SELECTION: [CallbackQueryHandler(select_roles)],
-            SELECTING_CARDS: [CallbackQueryHandler(show_card_keyboard),
-                              CallbackQueryHandler(select_card)],
-            ELIMINATING: [CallbackQueryHandler(handle_elimination)],
-            GAME_OVER: [MessageHandler(Filters.text & ~Filters.command, end_game)],
+            SELECTING_PLAYERS: [CallbackQueryHandler(select_players, pattern=r"^players:")],
+            ROLES_SELECTION: [CallbackQueryHandler(select_roles, pattern=r"^roles:")],
+            SELECTING_CARDS: [CallbackQueryHandler(select_card, pattern=r"^card:")],
+            ELIMINATING: [CallbackQueryHandler(handle_elimination, pattern=r"^eliminate:")],
         },
-        fallbacks=[CommandHandler('end', end_game)],
+        fallbacks=[CommandHandler("end", cancel_game), CommandHandler("cancel", cancel_game)],
+        per_chat=True,
     )
-    dp.add_handler(conv_handler)
 
-    # Start the Bot
-    updater.start_polling()
-    updater.idle()
+    application.add_handler(conv_handler)
+    application.add_handler(CommandHandler("end", cancel_game))
+
+    application.run_polling()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- replace the old global-state based implementation with a structured `GameSession`
- rewrite each bot interaction (player count, role selection, card picking, elimination) as dedicated callback handlers
- add helper keyboards and victory handling so the undercover game can be played end-to-end via inline buttons

## Testing
- python -m compileall suskia.py

------
https://chatgpt.com/codex/tasks/task_e_68c97fe777d0832dba084ac0479fdd60